### PR TITLE
fix(package): replace wildcard exports with barrel entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Getting Started
 
 ```js
-const { SparseMerkleTree } = require('@railgun-reloaded/merkle-tree/sparse-merkle-tree')
+import { SparseMerkleTree } from '@railgun-reloaded/merkle-tree'
 
 const treeDepth = 16
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@
 
 ## Getting Started
 
-```js
-import { SparseMerkleTree } from '@railgun-reloaded/merkle-tree'
+```ts
+import { SparseMerkleTree } from "@railgun-reloaded/merkle-tree";
 
-const treeDepth = 16
+const treeDepth = 16;
 
-const zeroElement = new Uint8Array(32)
+const zeroElement = new Uint8Array(32);
 
 const hashFn = (out, left, right) => {
-  crypto.createHash('sha3-256').update(left).update(right).digest(out)
-}
+  crypto.createHash("sha3-256").update(left).update(right).digest(out);
+};
 
-const tree = SparseMerkleTree.create({ treeDepth, zeroElement, hashFn })
+const tree = SparseMerkleTree.create({ treeDepth, zeroElement, hashFn });
 
 // Append three leaves to the tree
-const newLength = tree.append([node1, node2, node3])
+const newLength = tree.append([node1, node2, node3]);
 
 // Get the root node of the tree
-const rootNode = tree.root()
+const rootNode = tree.root();
 
 // Generate a proof for the second leaf of the tree
-const proofLeaf1 = tree.proof(1)
+const proofLeaf1 = tree.proof(1);
 
 // Serialize the tree to primitives that can be stored
-const flat = tree.serialize()
+const flat = tree.serialize();
 ```
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "directories": {
     "test": "test"
   },
-  "exports": {
-    "./*": "./src/*"
-  },
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export { MerkleTree } from './merkle-tree'
+export { SparseMerkleTree } from './sparse-merkle-tree'
+export type { InplaceMerkleHashFn, MerkleProof } from './types'


### PR DESCRIPTION
## Summary
- Replaces wildcard `exports` map with `main`/`types` fields, matching every other reloaded package
- Adds `src/index.ts` as the public API barrel re-exporting `MerkleTree`, `SparseMerkleTree`, `InplaceMerkleHashFn`, and `MerkleProof`
- Updates the README usage example to import from the package root

## Why
Under `moduleResolution: "nodenext"`, the wildcard subpath `exports` entry triggered strict ESM resolution semantics, which required full `.js` extensions on every subpath import (e.g. `@railgun-reloaded/merkle-tree/sparse-merkle-tree.js`). This was the only package in the workspace requiring that, and it forced downstream consumers into tsconfig `paths` workarounds. Aligning this package with `scanner`/`storage`/`cryptography` (legacy `main` + `types` fields, barrel entry point) removes the special case.

No runtime behavior changes — still compiles to CommonJS. Existing subpath imports continue to resolve via Node's legacy CJS subpath lookup, so this is non-breaking for any current consumer.