### PR TITLE
build: emit type declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 *.js
+*.d.ts
 *.tsbuildinfo
 
 !eslint.config.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "@railgun-reloaded/tsconfig/tsconfig"
-  ]
+  ],
+  "compilerOptions": {
+    "declaration": true
+  }
 }


### PR DESCRIPTION
Emit `.d.ts` declarations so consumers get pre-resolved types instead of falling through to the `.ts` source. Co-located output, gitignored locally, regenerated via the existing `prepare: tsc --build` hook on install.