### PR TITLE
Convert package to ESM

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,3 @@
-module.exports = require('@railgun-reloaded/eslint-config')()
+import railgunEslintConfig from '@railgun-reloaded/eslint-config'
+
+export default railgunEslintConfig()

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@railgun-reloaded/merkle-tree",
   "version": "0.0.0",
   "description": "Collection of Merkle Tree implementations as used in RAILGUN",
+  "type": "module",
   "directories": {
     "test": "test"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { MerkleTree } from './merkle-tree'
-export { SparseMerkleTree } from './sparse-merkle-tree'
-export type { InplaceMerkleHashFn, MerkleProof } from './types'
+export { MerkleTree } from './merkle-tree.js'
+export { SparseMerkleTree } from './sparse-merkle-tree.js'
+export type { InplaceMerkleHashFn, MerkleProof } from './types.js'

--- a/src/merkle-tree.ts
+++ b/src/merkle-tree.ts
@@ -1,7 +1,7 @@
 import tree from 'flat-tree'
 import assert from 'nanoassert'
 
-import type { InplaceMerkleHashFn, MerkleProof } from './types'
+import type { InplaceMerkleHashFn, MerkleProof } from './types.js'
 
 type CreateParams = { depth: number; hashFn: InplaceMerkleHashFn; zeroElement: Uint8Array }
 type ConstructorParams = { buf: Uint8Array; hashFn: InplaceMerkleHashFn; bytesPerElement: number }

--- a/src/sparse-merkle-tree.ts
+++ b/src/sparse-merkle-tree.ts
@@ -1,7 +1,7 @@
 import assert from 'nanoassert'
 
-import type { ConstructorParams as MTConstructorParams, CreateParams as MTCreateParams, Serialized as MTSerialized } from './merkle-tree'
-import { MerkleTree } from './merkle-tree'
+import type { ConstructorParams as MTConstructorParams, CreateParams as MTCreateParams, Serialized as MTSerialized } from './merkle-tree.js'
+import { MerkleTree } from './merkle-tree.js'
 
 type CreateParams = { length?: number } & MTCreateParams
 type ConstructorParams = { length?: number } & MTConstructorParams

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { poseidonT3 } from './poseidonT3'
+import { poseidonT3 } from './poseidonT3.js'
 
 const u256 = {
   /**

--- a/test/merkle-tree.test.ts
+++ b/test/merkle-tree.test.ts
@@ -3,10 +3,11 @@ import { test } from 'node:test'
 
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3'
 
-import { SparseMerkleTree } from '../src/sparse-merkle-tree'
+import { SparseMerkleTree } from '../src/sparse-merkle-tree.js'
 
-import { field as Fp } from './babyjub'
-import { hash, u256 } from './helpers'
+import { field as Fp } from './babyjub.js'
+import fixtureTree from './fixture-tree.json' with { type: 'json' }
+import { hash, u256 } from './helpers.js'
 
 const RAILGUN_DEPTH = 16
 const RAILGUN_ZERO = u256.toBytes(Fp.create(Fp.fromBytes(keccak256('Railgun'))))
@@ -53,7 +54,7 @@ test('Fixture - Check against a checkpoint from RAILGUN ethereum', (t) => {
     zeroElement: RAILGUN_ZERO
   })
 
-  const data = require('./fixture-tree.json') as { treePosition: number, hash: string }[][]
+  const data = fixtureTree as { treePosition: number, hash: string }[][]
   const nodes = []
   for (const batch of data) {
     nodes.push(...batch.map(datum => u256.toBytes(BigInt(datum.hash))))


### PR DESCRIPTION
Converts this package to ESM-only output as part of moving the SDK to native ES modules (the foundation for running on browser and React Native runtimes).

## What changed
- `package.json` sets `"type": "module"` so the package emits and publishes ESM.
- All relative imports/exports now carry explicit `.js` extensions, as required by native Node ESM resolution.
- `eslint.config.js` converted from CommonJS to ESM.
- A fixture test that loaded JSON via `require('./fixture-tree.json')` now uses a static JSON import (`import ... with { type: 'json' }`), since `require` is unavailable under ESM.

No source logic changes; the public API is unchanged. Build, lint, and the full test suite pass under ESM.